### PR TITLE
Improve responsiveness by executing the action sooner.

### DIFF
--- a/libinput-gestures
+++ b/libinput-gestures
@@ -164,6 +164,7 @@ class GESTURE:
 class SWIPE(GESTURE):
     'Class to handle this type of gesture'
     SUPPORTED_MOTIONS = ('left', 'right', 'up', 'down')
+    threshold = 70
 
     def begin(self, fingers):
         'Initialise this gesture at the start of motion'
@@ -174,11 +175,14 @@ class SWIPE(GESTURE):
         'Update this gesture for a motion'
         self.data[0] += float(coords[2])
         self.data[1] += float(coords[3])
+        if abs(self.data[0] - self.data[1]) >= self.threshold:
+            self.end()
+            return True
 
     def end(self):
         'Action this gesture at the end of a motion sequence'
         # Require movement beyond a small threshhold.
-        if abs(self.data[0] - self.data[1]) >= 70:
+        if abs(self.data[0] - self.data[1]) >= self.threshold:
             if abs(self.data[0]) > abs(self.data[1]):
                 motion = 'left' if self.data[0] < 0 else 'right'
             else:
@@ -189,6 +193,7 @@ class SWIPE(GESTURE):
 class PINCH(GESTURE):
     'Class to handle this type of gesture'
     SUPPORTED_MOTIONS = ('in', 'out')
+    threshold = 0.1
 
     def begin(self, fingers):
         'Initialise this gesture at the start of motion'
@@ -198,10 +203,13 @@ class PINCH(GESTURE):
     def update(self, coords):
         'Update this gesture for a motion'
         self.data += 1.0 - float(coords[5])
+        if abs(self.data) > self.threshold:
+            self.end()
+            return True
 
     def end(self):
         'Action this gesture at the end of a motion sequence'
-        if self.data != 0.0:
+        if abs(self.data) > self.threshold:
             self.action('in' if self.data >= 0.0 else 'out')
 
 # Create gesture handler instances and insert them in handler lookup
@@ -319,7 +327,9 @@ for line in cmd.stdout:
     # Action each type of event
     if event == 'UPDATE':
         if handler:
-            handler.update(re.split(r'[ (/@]+', params))
+            result = handler.update(re.split(r'[ (/@]+', params))
+            if result:
+                handler = None
     elif event == 'BEGIN':
         handler = handlers.get(gesture)
         if handler:


### PR DESCRIPTION
As soon as we are confident of the direction of a swipe or pinch, execute the corresponding action.

There could be a situation where this is undesirable, e.g. if you start swiping the wrong way you won't really be able to change your mind. However the improved responsiveness feels a lot nicer so it might be worth it. An alternative would be to make the behaviour configurable but I haven't done that since for me at least, I always prefer to just have the gesture execute quickly (then I can undo it if I did the wrong thing.)