### PR TITLE
Fedora 25 doesn't ship with wmctrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ Debian and Ubuntu users also need to install `libinput-tools` if that
 package exists in your release:
 
     sudo apt-get install libinput-tools
+    
+
+Fedora (from fedora 25 and newer) needs to install `wmctrl` since wayland is the default window manager.
+
+    sudo dnf install wmctrl
 
 Install this software:
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ package exists in your release:
     sudo apt-get install libinput-tools
     
 
-Fedora (from fedora 25 and newer) needs to install `wmctrl` since wayland is the default window manager.
+Fedora (from fedora 25 and newer) users needs to install `wmctrl` since wayland is the default window manager.
 
     sudo dnf install wmctrl
 


### PR DESCRIPTION
I needed to install it in order to have the gestures working again :) 