### PR TITLE
Fix arguments order

### DIFF
--- a/libinput-gestures
+++ b/libinput-gestures
@@ -49,9 +49,8 @@ def run(*args, check=True, **kwargs):
     result.stderr = None
     result.returncode = 0
     try:
-        result.stdout = subprocess.check_output(*args, **kwargs,
-                stderr=(None if check else subprocess.DEVNULL),
-                universal_newlines=True)
+        result.stdout = subprocess.check_output(stderr=(None if check else subprocess.DEVNULL),
+                universal_newlines=True, *args, **kwargs)
     except Exception as e:
         result.stderr = str(e)
         result.returncode = 1


### PR DESCRIPTION
I am getting a following error:

> spiderx@dia ~/libinput/libinput-gestures $ ./libinput-gestures
>   File "./libinput-gestures", line 52
>     result.stdout = subprocess.check_output(*args, **kwargs,
>                                                            ^
> SyntaxError: invalid syntax
> 

This PR fixes it.
More info is on [StackOverflow](http://stackoverflow.com/questions/18453290/funcargs-kwargs-x-throwing-invalid-syntax).