### PR TITLE
system restart instead of closing session

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ to read the touchpad device:
 
     sudo gpasswd -a $USER input
 
-After executing the above command, **log out of your session
-completely**, and then log back in to assign this group.
+After executing the above command, **restart you system completely**, 
+and then log back in to assign this group.
 
 NOTE: Arch users can just install [_libinput-gestures from the
 AUR_][AUR]. Then skip to the next CONFIGURATION section.


### PR DESCRIPTION
There are [several issues](https://github.com/bulletmark/libinput-gestures/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20Could%20not%20determine) that could have been avoided by just let the users reboot the system instead of just closing the session. Issue #87 is the latest example that would not have been opened if there was this 'restart' description.