### PR TITLE
Use Path.stem instead of Path.name in daemon

### DIFF
--- a/libinput-gestures
+++ b/libinput-gestures
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from pathlib import Path
 from distutils.version import LooseVersion as Version
 
-PROG = Path(sys.argv[0]).name
+PROG = Path(sys.argv[0]).stem
 
 # Conf file containing gesture commands.
 # Search first for user file then system file.


### PR DESCRIPTION
With this change, the daemon uses the `Path.stem` property instead of the
`Path.name` one to determine the script name (and hence derive the config
file name from). With the version of the daemon as it is implemented in
the repository right now, there is no difference; both properties yield
the very same result (because the daemon file has no file name
extension, the stem is identical to the name).

However, this change makes sense when e.g. distributions of the script
are patched as e.g. in https://gitlab.com/rpdev/fedora-multitouch. This
project installs the daemon as `libinput-gestures.py` and adds a
`setgid` wrapper called `libinput-gestures` to avoid users have to be
added to the `input` group. By default, in such a setup the daemon would
look for a different config file name (e.g.
`/etc/libinput-gestures.py.conf`). Using the `stem` instead of `name`
means the daemon works properly in both use cases (without additional
patching being required).