### PR TITLE
Adding documentation about xdotool set_desktop to the default config.

### DIFF
--- a/libinput-gestures.conf
+++ b/libinput-gestures.conf
@@ -92,6 +92,15 @@ gesture swipe right	xdotool key alt+Left
 # gesture swipe left	xdotool key ctrl+alt+Left
 # gesture swipe right	xdotool key ctrl+alt+Right
 
+# Some times using xdotool to input keys could be annoying
+# as programs like vim could capture the key strokes.
+# A better way to use xdotool to change workspaces is to use xdotool set_desktop
+# Assume a 3x3 grid of workspaces, the following config can be used.
+# gesture swipe left xdotool set_desktop --relative 1
+# gesture swipe right xdotool set_desktop --relative -- -1
+# gesture swipe up xdotool set_desktop --relative -- -3
+# gesture swipe down xdotool set_desktop --relative 3
+
 # GNOME SHELL open/close overview (works for GNOME on Wayland and Xorg)
 gesture pinch in dbus-send --session --type=method_call --dest=org.gnome.Shell /org/gnome/Shell org.gnome.Shell.Eval string:'Main.overview.toggle();'
 


### PR DESCRIPTION
The additional info helped me in resolving an annoying issue in Ubuntu Gnome 16.04 where the xdotool key strokes were captured by my editors. Might be useful to more users and might make sense to add it here.