### PR TITLE
fixed vertical wrapping for _internal

### DIFF
--- a/libinput-gestures
+++ b/libinput-gestures
@@ -214,7 +214,9 @@ class COMMAND_internal(COMMAND):
             if index == minindex - count:
                 index = maxindex - count
             elif index >= maxindex:
-                index = minindex
+                index = minindex + (index - maxindex)
+            elif index < minindex:
+                index = maxindex - (index - minindex)
 
         # Switch to desired workspace
         if index >= minindex and index < maxindex:


### PR DESCRIPTION
Previous behaviour for wrap was incorrect as it is changing to the first work space during overflow. Now it will wrap. It will wrap for underflow as well.