### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ package exists in your release:
 
 Install this software:
 
-    git clone http://github.com/bulletmark/libinput-gestures
+    git clone https://github.com/bulletmark/libinput-gestures.git
     cd libinput-gestures
     sudo make install (or sudo ./libinput-gestures-setup install)
 


### PR DESCRIPTION
link fix.
changed 
git clone http://github.com/bulletmark/libinput-gestures
to 
git clone https://github.com/bulletmark/libinput-gestures.git
To prevent fatal error while cloning-
fatal: http://github.com/bulletmark/libinput-gestures.git/info/refs not valid: is this a git repository?