### PR TITLE
ACL through udev

### DIFF
--- a/53-example-touchpad-udev.rules
+++ b/53-example-touchpad-udev.rules
@@ -1,0 +1,37 @@
+# udev rules for Touchpad gestures
+#   => Give access to control interface to user
+#   => Do not to give control over other interfaces
+#
+# Key/value pairs can be found by:
+#
+#     udevadm info -a /dev/input/eventX
+#
+# where X is the number relating to the touchpad.
+#
+# To verify your udev rules update, run the following 
+# (the info command will provide you the correct parameter 
+# for `test` below):
+#
+#    sudo udevadm control -R; sudo udev trigger
+#    sudo udevadm test /devices/platform/{. . .}/input/inputX/eventY
+#
+# again where X,Y, etc., are the numbers relating to your 
+# touchpad device found by the `info` commend above.
+#
+# You will find information such as
+#
+#    TAGS=:uaccess:seat:
+#    USEC_INITIALIZED=xxxx
+#    run: 'uaccess'
+#
+# as part of the output of the touchpad device test.
+
+ACTION=="add", KERNEL=="event*", SUBSYSTEM=="input", SUBSYSTEMS=="input", ATTRS{name}=="ETPS/2 Elantech Touchpad", GOTO="elantech"
+
+GOTO="end"
+
+LABEL="elantech"
+TAG+="uaccess"
+
+LABEL="end"
+# vim: ft=udevrules

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ https://github.com/bulletmark/libinput-gestures.
 
 ### INSTALLATION
 
-IMPORTANT: You must be a member of the _input_ group to have permission
+NOTE User access option 1: You must be a member of the _input_ group to have permission
 to read the touchpad device:
 
     sudo gpasswd -a $USER input
@@ -36,6 +36,13 @@ to read the touchpad device:
 After executing the above command, **log out of your session
 completely**, and then log back in to assign this group (or just
 reboot).
+
+NOTE User access option 2: For automated handling of ACL through udev, you may 
+instead copy/symlink the included `53-example-touchpad-udev.rules` file to 
+`/etc/udev/rules.d/` once you find the correct key/value pairs to use for your 
+hardware.  Instructions are provided in the comments of the rules file.
+
+After verifying the udev rule, just reboot and login.
 
 NOTE: Arch users can just install [_libinput-gestures from the
 AUR_][AUR]. Then skip to the next CONFIGURATION section.


### PR DESCRIPTION
Added ACL uacess option using udev on Ubuntu 18.10.  I can possibly add systemd changes later if desired.