### PR TITLE
Allow libinput-gestures to be run without homedir

### DIFF
--- a/libinput-gestures
+++ b/libinput-gestures
@@ -461,7 +461,7 @@ def unexpanduser(cfile):
     relslash = Path(os.path.abspath(str(cfile)))
     try:
         relhome = relslash.relative_to(os.getenv('HOME'))
-    except ValueError:
+    except (ValueError, TypeError):
         relhome = None
 
     return ('~/' + str(relhome)) if relhome else str(relslash)


### PR DESCRIPTION
This allows libinput-gestures to be run as a root user without a home directory. Running as root is the most straightforward route to running [ydotool](https://github.com/ReimuNotMoe/ydotool) commands from libinput-gestures, and root frequently doesn't have a home dir.

Prior to this changes when libinput-gestures was run as a user without a home dir `relslash.relative_to` would raise a `TypeError` upon receiving None as an argument.