### PR TITLE
Fixes typo in `launch` for i3

### DIFF
--- a/libinput-gestures-setup
+++ b/libinput-gestures-setup
@@ -65,7 +65,8 @@ launch() {
     fi
 
     if hash i3-msg &>/dev/null; then
-	i3-msg exec $BINDIR/$APP >/dev/null
+	i3-msg exec $BINDIR/$app >/dev/null
+	# i3-msg will return successfully even if "$app" fails to start
 	return $?
     fi
 


### PR DESCRIPTION
Two fixes:
- rename undefined variable `$APP` to `$app` in `launch`
- add note for future editors that `i3-msg` does not return exit code of program it execs