### PR TITLE
zooms multiple steps with one pinch gesture

### DIFF
--- a/libinput-gestures
+++ b/libinput-gestures
@@ -5,6 +5,7 @@ import os, sys, argparse, subprocess, shlex, re, getpass, fcntl, platform, math
 from collections import OrderedDict
 from pathlib import Path
 from distutils.version import LooseVersion as Version
+import threading
 
 PROGPATH = Path(sys.argv[0])
 PROGNAME = PROGPATH.stem
@@ -154,6 +155,7 @@ def get_device(name):
 
 class COMMAND:
     'Generic command handler'
+
     def __init__(self, args):
         self.reprstr = ' '.join(args)
 
@@ -179,6 +181,7 @@ def add_internal_command(cls):
 @add_internal_command
 class COMMAND_internal(COMMAND):
     'Internal command handler.'
+
     def __init__(self, args):
         'Action internal swipe commands'
         super().__init__(args)
@@ -249,6 +252,7 @@ def add_gesture_handler(cls):
 
 class GESTURE:
     'Abstract base class for handling for gestures'
+
     def __init__(self):
         'Initialise this gesture at program start'
         self.name = type(self).__name__
@@ -343,6 +347,7 @@ class SWIPE(GESTURE):
 
         self.action(motion)
 
+
 @add_gesture_handler
 class PINCH(GESTURE):
     'Class to handle this type of gesture'
@@ -355,6 +360,15 @@ class PINCH(GESTURE):
         try:
             x = float(coords[4])
             y = float(coords[5])
+
+            score = x - y
+            if 0.95 < score < 1:
+                self.end()
+            if 1.95 < score < 2:
+                self.end()
+            if 2.95 < score < 3:
+                self.end()
+
         except (ValueError, IndexError):
             return False
 
@@ -365,7 +379,7 @@ class PINCH(GESTURE):
     def end(self):
         'Action this gesture at the end of a motion sequence'
         ratio, angle = self.data
-
+        print("END")
         if self.has_extended and abs(angle) > ROTATE_ANGLE:
             self.action('clockwise' if angle >= 0.0 else 'anticlockwise')
         elif ratio != 0.0:

--- a/libinput-gestures.conf
+++ b/libinput-gestures.conf
@@ -64,10 +64,11 @@ gesture swipe down	_internal ws_down
 # gesture swipe down	xdotool key super+Page_Up
 
 # Browser go forward (works only for Xorg, and Xwayland clients)
-gesture swipe left	xdotool key alt+Right
+gesture swipe left	notify-send works
 
 # Browser go back (works only for Xorg, and Xwayland clients)
 gesture swipe right	xdotool key alt+Left
+
 
 # NOTE: If you don't use "natural" scrolling direction for your touchpad
 # then you may want to swap the above default left/right and up/down
@@ -115,8 +116,8 @@ gesture swipe right	xdotool key alt+Left
 ###############################################################################
 
 # GNOME SHELL open/close overview (works for GNOME on Xorg only)
-gesture pinch in	xdotool key super+s
-gesture pinch out	xdotool key super+s
+gesture pinch in	xdotool key alt+minus
+gesture pinch out	xdotool key alt+plus
 
 # KDE Plasma open/close overview
 # gesture pinch in	xdotool key ctrl+F9


### PR DESCRIPTION
I added support so you could zoom multiple steps with one pinch out / in gesture. Before this fix you were only able to execute one zoom step with one gesture, now you are able to zoom more fluid using 3 steps with just one gesture.
