### PR TITLE
Fix spawned child processes superseding PIPE to libinput debug-events

### DIFF
--- a/libinput-gestures
+++ b/libinput-gestures
@@ -173,7 +173,10 @@ class COMMAND:
 
     def run(self):
         'Run this command + arguments'
-        run(self.argslist)
+        try:
+            subprocess.Popen(self.argslist)
+        except Exception as e:
+            print(str(e), file=sys.stderr)
 
     def __str__(self):
         'Return string representation'


### PR DESCRIPTION
Changed COMMAND.run() to call subprocess.Popen() instead of subprocess.check_output() via run()

check_output() by default sets subprocess.PIPE to the stdout of the newly created process, which will supersede libinput debug-events and cause libinput-gestures to stop processing gestures.