### PR TITLE
Remove "GNOME;GTK;" from libinput-gestures.desktop

### DIFF
--- a/libinput-gestures.desktop
+++ b/libinput-gestures.desktop
@@ -6,4 +6,4 @@ Name=Libinput Gestures
 Exec=/usr/bin/libinput-gestures
 Icon=libinput-gestures
 Comment=Background application to intercept and action libinput gestures from touchpad.
-Categories=GNOME;GTK;System;
+Categories=System;


### PR DESCRIPTION
I don't think it makes any sense to add these two categories.