### PR TITLE
Add systemd service

### DIFF
--- a/libinput-gestures.service
+++ b/libinput-gestures.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Actions gestures on your touchpad using libinput
+Documentation=https://github.com/bulletmark/libinput-gestures
+PartOf=graphical-session.target
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/libinput-gestures
+
+[Install]
+WantedBy=graphical-session.target


### PR DESCRIPTION
Some users use systemd user services to manage session startup applications.
Systemd is used in most popular distributions, so it might be handy to provide such service file as part of application and not as part of particular distribution: https://aur.archlinux.org/packages/libinput-gestures-git/#comment-792261.