### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Install this software:
 
     git clone https://github.com/bulletmark/libinput-gestures.git
     cd libinput-gestures
-    sudo make install (or sudo ./libinput-gestures-setup install)
+    sudo make install # Or sudo ./libinput-gestures-setup install
 
 ### CONFIGURATION
 
@@ -216,7 +216,7 @@ You can switch back to the desktop option with the command:
 
     # cd to source dir, as above
     git pull
-    sudo make install (or sudo ./libinput-gestures-setup install)
+    sudo make install # Or sudo ./libinput-gestures-setup install
     libinput-gestures-setup restart
 
 ### REMOVAL


### PR DESCRIPTION
When making use of the 'copy to clipboard' button on github for the install instruction, the install script fails due to the (or sudo ./libinput-gestures-setup install) being invalid syntax.

I think this change still keeps it clear that the alternate option exists, but enables the command to be ran without having to be edited after pasting.

Also applied to the 'UPGRADING' script
